### PR TITLE
proxy-http: bind to host port 1080

### DIFF
--- a/stable/proxy-http/README.md
+++ b/stable/proxy-http/README.md
@@ -3,5 +3,24 @@
 ## TL;DR;
 
 ```bash
-$ helm install proxy-http-x.x.x.tgz --name proxy-http --namespace proxy-http
+$ helm install proxy-http-x.x.x.tgz --name proxy --namespace proxy
 ```
+
+## Requirements
+
+For any environment, you'll need to provide:
+
+* proxyUrl: this URL should return a newline-delimited
+  list of upstreaam proxies. See [proxy/update-proxies](https://github.com/clearbit/proxy/blob/master/update-proxies) for details.
+* redisUrl: points to a dedicated redis DB. In dev, we deploy one
+  using the stable/redis chart.
+
+For production -- so that proxy-cronjob works properly -- you must
+also provide:
+
+* influxdbUrl: HTTP url for storing proxy-cronjob metrics.
+
+
+## Deployment
+
+See [proxy/README.md](https://github.com/clearbit/proxy/blob/master/README.md).

--- a/stable/proxy-http/templates/deployment.yaml
+++ b/stable/proxy-http/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         ports:
         - name: http
           containerPort: 1080
+          hostPort: 1080
           protocol: TCP
         - name: metrics
           containerPort: 9102

--- a/stable/proxy-http/values.yaml
+++ b/stable/proxy-http/values.yaml
@@ -19,7 +19,7 @@ memory: 400Mi
 nodeEnv: ""
 
 ## Influxdb URL
-influxDbUrl: ""
+influxDbUrl: "http://monitoring-influxdb.influxdb:8086"
 
 ## Schedule when to run
 # run every 12 hours


### PR DESCRIPTION
Update proxy-http chart so that the proxy service binds to port 1080,
per
https://trello.com/c/zjAzPUGD/9-switch-proxy-app-to-use-host-ports-rather-than-running-through-k8s-proxy .

This is coupled with a change in the proxy repo so that we can deploy
proxy into the dev cluster for testing via buildkite.