### PR TITLE
buildkite-builder: upgrade to 3.0-beta.29

### DIFF
--- a/stable/buildkite-builder/templates/deployment.yaml
+++ b/stable/buildkite-builder/templates/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         pod.beta.kubernetes.io/init-containers: '[
               {
                   "name": "download-docker-credential-ecr-login",
-                  "image": "{{ .Values.image }}-{{ .Values.dockerTag }}",
+                  "image": "{{ .Values.image }}",
                   "command": ["/bin/bash"],
                   "args": ["-c", "curl https://s3-us-west-1.amazonaws.com/apihub-coreos/buildkite/docker-credential-ecr-login > /usr/local/sbin/docker-credential-ecr-login; chmod +x /usr/local/sbin/docker-credential-ecr-login"],
                   "volumeMounts": [
@@ -33,7 +33,7 @@ spec:
       serviceAccount: {{ .Release.Name }}
       containers:
         - name: {{ .Release.Name }}
-          image: "{{ .Values.image }}-{{ .Values.dockerTag }}"
+          image: "{{ .Values.image }}"
           imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
           securityContext:
             privileged: true

--- a/stable/buildkite-builder/values.yaml
+++ b/stable/buildkite-builder/values.yaml
@@ -18,7 +18,8 @@ replicasCount: 4
 agentTag: "3.0"
 
 ## Agent meta-data, which can be used to assign jobs
-agentMeta: "role=builder"
+# This role should be builder-staging or builder-dev.
+#agentMeta: "role=builder"
 
 ## Your Buildkite agent token
 # agentToken: "token"

--- a/stable/buildkite-builder/values.yaml
+++ b/stable/buildkite-builder/values.yaml
@@ -1,7 +1,7 @@
 ## Buildkite agent image version
 ## ref: https://hub.docker.com/r/buildkite/agent/
 ##
-image: buildkite/agent:ubuntu-docker
+image: buildkite/agent:3.0-beta.29
 
 ## Specify a imagePullPolicy
 ## 'Always' if imageTag is 'latest', else set to 'IfNotPresent'
@@ -9,8 +9,6 @@ image: buildkite/agent:ubuntu-docker
 ##
 imagePullPolicy: Always
 
-## Agent docker image tag
-dockerTag: 1.12.1
 
 ## Replicas Set count
 replicasCount: 4
@@ -23,26 +21,26 @@ agentTag: "3.0"
 agentMeta: "role=builder"
 
 ## Your Buildkite agent token
-agentToken: "token"
+# agentToken: "token"
 
 ## Your ssh private key
-privateSshKey: "ssh_key"
+# privateSshKey: "ssh_key"
 
 ## AWS credentials needed to access ECR
-awsCreds: " "
+# awsCreds: " "
 
 ## Deis Workflow PaaS
 ## user token - client.json content encoded with base64
-workflowUserToken: " "
+# workflowUserToken: " "
 ##
 ## API URL
-workflowApiUrl: " "
+# workflowApiUrl: " "
 
 ## ANY EXTRA ENV VAR TO BE PASSED TO BUILDKITE AGENT
 ##
-extraEnvVar:
-  name: SOME_ENV_VAR
-  value: "some_value"
+# extraEnvVar:
+#   name: SOME_ENV_VAR
+#   value: "some_value"
 
 ## Node selector
 ## comment it out if you do need to use node selector


### PR DESCRIPTION
Upgrade buildkite agent to 3.0-beta.29, fixing the followup part of
https://trello.com/c/5J3iN6a3/2561-tests-run-with-compose-from-buildkite-may-never-exit